### PR TITLE
Add project: Simple Memo

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -258,9 +258,9 @@ projects:
     labels: [official]
     category: tools
     
-  - name: Inbox Markdown generator by Simple Memo
-    homepage: https://simplememofast.com/en/resources/obsidian-inbox/
-    description: "A free browser tool for previewing timestamped bullets or checkboxes for an Obsidian Inbox or daily note, then copying or downloading the Markdown. No signup, plugin, or vault access is required."
+  - name: Simple Memo
+    homepage: https://simplememofast.com/en/obsidian/
+    description: "An iPhone app that appends captured notes to an Obsidian Inbox or daily note. A separate free browser tool previews and exports Inbox Markdown without installing the app."
     category: tools
     resource: true
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -258,6 +258,12 @@ projects:
     labels: [official]
     category: tools
     
+  - name: Inbox Markdown generator by Simple Memo
+    homepage: https://simplememofast.com/en/resources/obsidian-inbox/
+    description: "A free browser tool for previewing timestamped bullets or checkboxes for an Obsidian Inbox or daily note, then copying or downloading the Markdown. No signup, plugin, or vault access is required."
+    category: tools
+    resource: true
+
   # ---------------------------------------------------------------------
   # 🌐 Static-Site-Generators
   # ---------------------------------------------------------------------


### PR DESCRIPTION
Adds Simple Memo to `tools`, with its Obsidian integration overview as the homepage. The entry describes the iPhone app and the separate free Inbox Markdown generator, which works without installing the app.

I maintain Simple Memo. It is an independent app, not an official Obsidian app or community plugin. The entry uses the documented `homepage` / `resource: true` format.

- App setup and limitations: https://simplememofast.com/en/obsidian/
- Standalone browser tool: https://simplememofast.com/en/resources/obsidian-inbox/
- Only `projects.yaml` is changed; the README is generated.
- The existing suggestion is updated in place, with one Simple Memo entry and no duplicate proposal.

Validation: checked the current contribution guidelines, both live pages and the revised YAML; unrelated entries are unchanged.
