### PR TITLE
Add project: Summarize Video To Text

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -216,6 +216,12 @@ projects:
     category: integrations
     homepage: https://ankiweb.net/shared/info/1162061440
     image: https://opengraph.githubassets.com/1/sajee05/anki_obsidian_sync
+
+  - name: Summarize Video To Text
+    homepage: https://summarizevideototext.com/obsidian-plugin
+    description: "A web service that turns YouTube, TikTok, Instagram and X videos into Obsidian notes - TL;DR, key points, timestamped chapters and the full transcript. Connect a free account once, then send notes straight into your vault, or export the Markdown by hand."
+    category: integrations
+    resource: true
     
   # ---------------------------------------------------------------------
   # 🛠️ Tools


### PR DESCRIPTION
Adds [Summarize Video To Text](https://summarizevideototext.com/obsidian-plugin) under **🔗 Integrations**.

### What it is

A web service that turns YouTube, TikTok, Instagram and X videos into Obsidian notes — TL;DR, key points, timestamped chapters and the full transcript. You connect a free account once and the notes land in your vault; you can also just download the Markdown and file it yourself.

### Why `integrations` and not `plugins` — please read before reviewing

I'm aware `CONTRIBUTING.md` says **plugins and themes are not yet accepted**, and I don't want to slip past that rule, so here is the full picture:

- The product is a **web service**. Obsidian is one of its outputs, alongside Notion export, plain Markdown download and `obsidian://` protocol links.
- It **does** also ship a community plugin, which is one of the ways the service writes into a vault. I'm not hiding that.
- I filed it under `integrations` because that category reads *"Connections between Obsidian and external apps, services, and platforms"*, and the entries already there — Alfred workflow, Raycast extension, Anki sync — are external tools rather than Obsidian plugins. `Simple Memo` (an iPhone app) was recently accepted under `tools` on what looks like the same basis.

**If you judge that this still falls under the plugin moratorium, please just close it** — no hard feelings, and I'll resubmit when the Plugins category opens up.

### Checklist

- [x] Not already present in `projects.yaml`, the README, or the issue list
- [x] Added to `projects.yaml`, not to `README.md` directly
- [x] One project per pull request
- [x] Title follows `Add project: <name>`
- [x] YAML parses cleanly (43 projects, entry lands in the Integrations block)
